### PR TITLE
docs: fix grammar and typos in documentation

### DIFF
--- a/POSTGRESQL.md
+++ b/POSTGRESQL.md
@@ -25,7 +25,7 @@ This section covers connecting to a PostgreSQL database instance.
 2.  **Handle Missing Variables**: If a command fails with an error message containing a placeholder like `${POSTGRES_HOST}`, it signifies a missing environment variable. Inform the user which variable is missing and instruct them to set it.
 
 3.  **Handle Permission Errors**: If an operation fails due to permission, it is
-    likely that the user do not have the correct privileges on the PostgreSQL
+    likely that the user does not have the correct privileges on the PostgreSQL
     database. Database-level permissions (e.g., `SELECT`, `INSERT`) are required
     to execute queries.
 
@@ -53,7 +53,7 @@ Users may have set project environment variables:
  *   `POSTGRES_USER`: The username for authentication.
  *   `POSTGRES_PASSWORD`: The password for authentication.
 
-Instead of prompting the user for these values for specific tool calls, prompt the user to verify reuse a specific value.
+Instead of prompting the user for these values for specific tool calls, prompt the user to verify and reuse a specific value.
 Make sure to not use the environment variable name like `POSTGRES_HOST`, `${POSTGRES_HOST}`, or `$POSTGRES_HOST`. The value can be found by using command: `echo $POSTGRES_HOST`.
 
 ## Use Full Table Name Format "DATABASE_NAME.SCHEMA_NAME.TABLE_NAME"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Before you begin, ensure you have the following:
 * [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed with version **+v0.6.0**.
 * Setup Gemini CLI [Authentication](https://github.com/google-gemini/gemini-cli/tree/main?tab=readme-ov-file#-authentication-options).
 * A running PostgreSQL instance.
-* User are granted database-level permissions to execute queries.
+* Users are granted database-level permissions to execute queries.
 
 ## Getting Started
 
@@ -78,8 +78,8 @@ Interact with Postgres using natural language right from your IDE:
 
 ## Supported Tools
 
- * `list_tables`: Use this tool to lists tables in the database.
- * `execute_sql`: Use this tool to executes a SQL query.
+ * `list_tables`: Use this tool to list tables in the database.
+ * `execute_sql`: Use this tool to execute a SQL query.
  * `list_active_queries`: Use this tool to list currently running queries.
  * `list_available_extensions`: Use this tool to list available extensions for installation.
  * `list_installed_extensions`: Use this tool to list installed extensions.


### PR DESCRIPTION
Fixes grammar issues and typos across documentation files.

### Changes
- **README.md**: Fix subject-verb agreement ("User are" → "Users are")
- **README.md**: Fix verb forms in tool descriptions ("lists" → "list", "executes" → "execute")
- **POSTGRESQL.md**: Fix grammar ("user do not" → "user does not")
- **POSTGRESQL.md**: Fix missing word ("verify reuse" → "verify and reuse")