### PR TITLE
feat: adopt Agent Plugin spec and generate harness manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "postgres",
+  "owner": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "metadata": {
+    "description": "Connect and interact with a PostgreSQL database and data."
+  },
+  "plugins": [
+    {
+      "name": "postgres",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,69 @@
+{
+  "name": "postgres",
+  "version": "0.2.2",
+  "description": "Connect and interact with a PostgreSQL database and data",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/postgres",
+  "license": "Apache-2.0",
+  "userConfig": {
+    "postgres_host": {
+      "title": "Host",
+      "description": "Host or IP address of the PostgreSQL server",
+      "type": "string",
+      "sensitive": false
+    },
+    "postgres_port": {
+      "title": "Port",
+      "description": "Port number of the PostgreSQL server",
+      "type": "string",
+      "sensitive": false
+    },
+    "postgres_database": {
+      "title": "Database",
+      "description": "Name of the database",
+      "type": "string",
+      "sensitive": false
+    },
+    "postgres_user": {
+      "title": "User",
+      "description": "Username of the database user",
+      "type": "string",
+      "sensitive": false
+    },
+    "postgres_password": {
+      "title": "Password",
+      "description": "Password of the database user",
+      "type": "string",
+      "sensitive": true
+    },
+    "postgres_query_params": {
+      "title": "Query Params",
+      "description": "(Optional) Connection String Parameters",
+      "type": "string",
+      "sensitive": false
+    }
+  },
+  "mcpServers": {
+    "postgresql": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "postgres",
+        "--stdio"
+      ],
+      "env": {
+        "POSTGRES_HOST": "${user_config.postgres_host}",
+        "POSTGRES_PORT": "${user_config.postgres_port}",
+        "POSTGRES_DATABASE": "${user_config.postgres_database}",
+        "POSTGRES_USER": "${user_config.postgres_user}",
+        "POSTGRES_PASSWORD": "${user_config.postgres_password}",
+        "POSTGRES_QUERY_PARAMS": "${user_config.postgres_query_params}"
+      }
+    }
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,18 +9,6 @@
   "repository": "https://github.com/gemini-cli-extensions/postgres",
   "license": "Apache-2.0",
   "userConfig": {
-    "postgres_host": {
-      "title": "Host",
-      "description": "Host or IP address of the PostgreSQL server",
-      "type": "string",
-      "sensitive": false
-    },
-    "postgres_port": {
-      "title": "Port",
-      "description": "Port number of the PostgreSQL server",
-      "type": "string",
-      "sensitive": false
-    },
     "postgres_database": {
       "title": "Database",
       "description": "Name of the database",
@@ -38,6 +26,18 @@
       "description": "Password of the database user",
       "type": "string",
       "sensitive": true
+    },
+    "postgres_host": {
+      "title": "Host",
+      "description": "Host or IP address of the PostgreSQL server",
+      "type": "string",
+      "sensitive": false
+    },
+    "postgres_port": {
+      "title": "Port",
+      "description": "Port number of the PostgreSQL server",
+      "type": "string",
+      "sensitive": false
     },
     "postgres_query_params": {
       "title": "Query Params",
@@ -57,11 +57,11 @@
         "--stdio"
       ],
       "env": {
-        "POSTGRES_HOST": "${user_config.postgres_host}",
-        "POSTGRES_PORT": "${user_config.postgres_port}",
         "POSTGRES_DATABASE": "${user_config.postgres_database}",
         "POSTGRES_USER": "${user_config.postgres_user}",
         "POSTGRES_PASSWORD": "${user_config.postgres_password}",
+        "POSTGRES_HOST": "${user_config.postgres_host}",
+        "POSTGRES_PORT": "${user_config.postgres_port}",
         "POSTGRES_QUERY_PARAMS": "${user_config.postgres_query_params}"
       }
     }

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "postgresql": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "postgres",
+        "--stdio"
+      ],
+      "env_vars": [
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_DATABASE",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_QUERY_PARAMS"
+      ]
+    }
+  }
+}

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -10,11 +10,11 @@
         "--stdio"
       ],
       "env_vars": [
-        "POSTGRES_HOST",
-        "POSTGRES_PORT",
         "POSTGRES_DATABASE",
         "POSTGRES_USER",
         "POSTGRES_PASSWORD",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
         "POSTGRES_QUERY_PARAMS"
       ]
     }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "postgres",
+  "version": "0.2.2",
+  "description": "Connect and interact with a PostgreSQL database and data",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/postgres",
+  "license": "Apache-2.0",
+  "mcpServers": "./.codex-plugin/.mcp.json"
+}

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ See [Configuration](#configuration) for how each harness supplies the connection
 
 The plugin connects to PostgreSQL using these settings:
 
-*   `POSTGRES_HOST`: (Optional) The Postgres host. Defaults to `localhost`.
-*   `POSTGRES_PORT`: (Optional) The Postgres port. Defaults to `5432`.
 *   `POSTGRES_DATABASE`: The name of the database to connect to.
 *   `POSTGRES_USER`: The database username.
 *   `POSTGRES_PASSWORD`: The password for the database user.
+*   `POSTGRES_HOST`: (Optional) The Postgres host. Defaults to `localhost`.
+*   `POSTGRES_PORT`: (Optional) The Postgres port. Defaults to `5432`.
 *   `POSTGRES_QUERY_PARAMS`: (Optional) Connection string parameters.
 
 How you supply them depends on the harness:
@@ -85,11 +85,11 @@ How you supply them depends on the harness:
 *   **Codex** and **Antigravity**: export the variables in your shell before starting:
 
 ```bash
-export POSTGRES_HOST="<your-postgres-host>"                    # Optional, defaults to localhost
-export POSTGRES_PORT="<your-postgres-port>"                    # Optional, defaults to 5432
 export POSTGRES_DATABASE="<your-database-name>"
 export POSTGRES_USER="<your-database-user>"
 export POSTGRES_PASSWORD="<your-database-password>"
+export POSTGRES_HOST="<your-postgres-host>"                    # Optional, defaults to localhost
+export POSTGRES_PORT="<your-postgres-port>"                    # Optional, defaults to 5432
 export POSTGRES_QUERY_PARAMS="<your-connection-string-params>" # Optional
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ Learn more about [Gemini CLI Extensions](https://github.com/google-gemini/gemini
 
 Before you begin, ensure you have the following:
 
-* [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed with version **+v0.6.0**.
-* Setup Gemini CLI [Authentication](https://github.com/google-gemini/gemini-cli/tree/main?tab=readme-ov-file#-authentication-options).
+* One of the supported agent harnesses, installed and authenticated:
+  * [Gemini CLI](https://github.com/google-gemini/gemini-cli) (v0.6.0+)
+  * [Claude Code](https://code.claude.com)
+  * [Codex](https://developers.openai.com/codex)
+  * [Antigravity CLI](https://antigravity.google)
+* [Node.js](https://nodejs.org/) (the MCP server runs via `npx`).
 * A running PostgreSQL instance.
 * Users are granted database-level permissions to execute queries.
 
@@ -33,42 +37,60 @@ Before you begin, ensure you have the following:
 
 ### Installation
 
-To install the extension, use the command:
+All harnesses use the same plugin; the MCP server runs via `npx` (no binary to download). Install with your harness of choice:
+
+**Gemini CLI**
 
 ```bash
 gemini extensions install https://github.com/gemini-cli-extensions/postgres
 ```
 
+**Claude Code**
+
+```bash
+claude plugin marketplace add gemini-cli-extensions/postgres
+claude plugin install postgres@postgres
+```
+
+**Codex**
+
+```bash
+codex plugin marketplace add gemini-cli-extensions/postgres
+codex plugin add postgres@postgres
+```
+
+**Antigravity**
+
+```bash
+agy plugin install https://github.com/gemini-cli-extensions/postgres
+```
+
+See [Configuration](#configuration) for how each harness supplies the connection settings.
+
 ### Configuration
 
-You will be prompted to configure the following settings during installation. These settings are saved in an `.env` file within the extension's directory.
+The plugin connects to PostgreSQL using these settings:
 
 *   `POSTGRES_HOST`: (Optional) The Postgres host. Defaults to `localhost`.
 *   `POSTGRES_PORT`: (Optional) The Postgres port. Defaults to `5432`.
 *   `POSTGRES_DATABASE`: The name of the database to connect to.
 *   `POSTGRES_USER`: The database username.
 *   `POSTGRES_PASSWORD`: The password for the database user.
+*   `POSTGRES_QUERY_PARAMS`: (Optional) Connection string parameters.
 
-To view or update your configuration:
+How you supply them depends on the harness:
 
-**List Settings:**
-*   Terminal: `gemini extensions list`
-*   Gemini CLI: `/extensions list`
-
-**Update Settings:**
-*   Terminal: `gemini extensions config postgres [setting name] [--scope <scope>]`
-    *   `setting name`: (Optional) The single setting to configure.
-    *   `scope`: (Optional) The scope of the setting in (`user` or `workspace`). Defaults to `user`.
-*   Currently, you must restart the Gemini CLI for changes to take effect. We recommend using `gemini --resume` to resume your session.
-
-Alternatively, you can manually set these environment variables before starting the Gemini CLI:
+*   **Gemini CLI**: prompted on install and saved to the extension's `.env`. View or update later with `gemini extensions list` / `gemini extensions config postgres [setting] [--scope user|workspace]` (restart the CLI to apply).
+*   **Claude Code**: pass `--config KEY=VALUE` on install (repeatable), or run `/plugin` inside Claude Code.
+*   **Codex** and **Antigravity**: export the variables in your shell before starting:
 
 ```bash
-export POSTGRES_HOST="<your-postgres-host>" # Optional: defaults to localhost
-export POSTGRES_PORT="<your-postgres-port>" # Optional: defaults to 5432
+export POSTGRES_HOST="<your-postgres-host>"                    # Optional, defaults to localhost
+export POSTGRES_PORT="<your-postgres-port>"                    # Optional, defaults to 5432
 export POSTGRES_DATABASE="<your-database-name>"
 export POSTGRES_USER="<your-database-user>"
 export POSTGRES_PASSWORD="<your-database-password>"
+export POSTGRES_QUERY_PARAMS="<your-connection-string-params>" # Optional
 ```
 
 > [!NOTE]

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -17,16 +17,6 @@
   "contextFileName": "POSTGRESQL.md",
   "settings": [
     {
-      "name": "Host",
-      "description": "Host or IP address of the PostgreSQL server",
-      "envVar": "POSTGRES_HOST"
-    },
-    {
-      "name": "Port",
-      "description": "Port number of the PostgreSQL server",
-      "envVar": "POSTGRES_PORT"
-    },
-    {
       "name": "Database",
       "description": "Name of the database",
       "envVar": "POSTGRES_DATABASE"
@@ -40,6 +30,16 @@
       "name": "Password",
       "description": "Password of the database user",
       "envVar": "POSTGRES_PASSWORD"
+    },
+    {
+      "name": "Host",
+      "description": "Host or IP address of the PostgreSQL server",
+      "envVar": "POSTGRES_HOST"
+    },
+    {
+      "name": "Port",
+      "description": "Port number of the PostgreSQL server",
+      "envVar": "POSTGRES_PORT"
     },
     {
       "name": "Query Params",

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "postgresql": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "postgres",
+        "--stdio"
+      ]
+    }
+  }
+}

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "postgresql": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "postgres",
+        "--stdio"
+      ]
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,52 @@
+{
+  "name": "postgres",
+  "version": "0.2.2",
+  "description": "Connect and interact with a PostgreSQL database and data",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/postgres",
+  "license": "Apache-2.0",
+  "extensions": {
+    "com.google.cloud.data.agent-plugins": {
+      "config": [
+        {
+          "key": "POSTGRES_HOST",
+          "title": "Host",
+          "description": "Host or IP address of the PostgreSQL server"
+        },
+        {
+          "key": "POSTGRES_PORT",
+          "title": "Port",
+          "description": "Port number of the PostgreSQL server"
+        },
+        {
+          "key": "POSTGRES_DATABASE",
+          "title": "Database",
+          "description": "Name of the database"
+        },
+        {
+          "key": "POSTGRES_USER",
+          "title": "User",
+          "description": "Username of the database user"
+        },
+        {
+          "key": "POSTGRES_PASSWORD",
+          "title": "Password",
+          "description": "Password of the database user",
+          "sensitive": true
+        },
+        {
+          "key": "POSTGRES_QUERY_PARAMS",
+          "title": "Query Params",
+          "description": "(Optional) Connection String Parameters"
+        }
+      ],
+      "gemini": {
+        "contextFileName": "POSTGRESQL.md",
+        "mcpServerName": "postgresql"
+      }
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -12,16 +12,6 @@
     "com.google.cloud.data.agent-plugins": {
       "config": [
         {
-          "key": "POSTGRES_HOST",
-          "title": "Host",
-          "description": "Host or IP address of the PostgreSQL server"
-        },
-        {
-          "key": "POSTGRES_PORT",
-          "title": "Port",
-          "description": "Port number of the PostgreSQL server"
-        },
-        {
           "key": "POSTGRES_DATABASE",
           "title": "Database",
           "description": "Name of the database"
@@ -36,6 +26,16 @@
           "title": "Password",
           "description": "Password of the database user",
           "sensitive": true
+        },
+        {
+          "key": "POSTGRES_HOST",
+          "title": "Host",
+          "description": "Host or IP address of the PostgreSQL server"
+        },
+        {
+          "key": "POSTGRES_PORT",
+          "title": "Port",
+          "description": "Port number of the PostgreSQL server"
         },
         {
           "key": "POSTGRES_QUERY_PARAMS",


### PR DESCRIPTION
## Summary

Adopts the vendor-neutral [Agent Plugin spec](https://agent-plugins.org) as the single source of truth for this extension and generates the per-harness manifests from it, so one plugin installs across Gemini CLI, Claude Code, Codex, and Antigravity.

> Stacked on `chore/npx-toolbox` (base branch). Review/merge that first.

## What changed

- **Spec source**: root `plugin.json` (no `$schema`, so Codex routes to the generated `.codex-plugin/`) and `mcp.json` (MCP server via `npx @toolbox-sdk/server`).
- **Generated harness manifests**:
  - Gemini CLI , `gemini-extension.json` (settings prompt to `.env`)
  - Claude Code , `.claude-plugin/plugin.json` (config via `userConfig` / `--config`)
  - Codex , `.codex-plugin/{plugin.json,.mcp.json}` (env forwarded via `env_vars`)
  - Antigravity , `mcp_config.json` (reads ambient shell env)
- **Marketplace**: `.claude-plugin/marketplace.json` , used by both Claude Code and Codex (Codex reads it via its discovery fallback), so no drift.
- **README**: installation and configuration documented for all four harnesses.

## Verification

Loaded the generated plugin on all four harnesses (plugin + skills load, MCP server starts, config/env resolves). Empirically confirmed each harness's config delivery: Gemini `.env`, Claude `userConfig` (ambient shell env is shadowed to empty for wired keys, so `--config` is required), Codex/AGY ambient shell env.
