### PR TITLE
fix(ci): restore pull_request_target for mirror-changelog

### DIFF
--- a/.github/workflows/mirror-changelog.yml
+++ b/.github/workflows/mirror-changelog.yml
@@ -15,7 +15,8 @@
 name: Mirror Toolbox Changelog
 
 on:
-  pull_request:
+  # Fork Renovate PRs need a write token; safe (no PR-code checkout, API-only).
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited]
 
 jobs:


### PR DESCRIPTION
Renovate PRs come from a fork (forking-renovate), and `pull_request` gives fork PRs a read-only token, so the changelog workflow's PR-body update 403s (e.g. #106).

Restore `pull_request_target` so it gets a write token. Safe here (no PR-code checkout, gated on renovate-bot, API-only body update), so the zizmor finding is suppressed inline.
