### PR TITLE
ci: point Renovate and release-please at the source manifests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "postgres",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Connect and interact with a PostgreSQL database and data",
   "author": {
     "name": "Google LLC",
@@ -51,7 +51,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "postgres",
         "--stdio"

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "postgres",
         "--stdio"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "postgres",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Connect and interact with a PostgreSQL database and data",
   "author": {
     "name": "Google LLC",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,9 +29,17 @@
   ],
   customManagers: [
     {
-      // Track the npm toolbox server pinned in the extension's MCP command.
+      // Track the npm toolbox server pinned in the MCP command. The version is
+      // listed in the source (mcp.json) and repeated in every generated
+      // manifest, so all of them are bumped in one PR.
       customType: "regex",
-      managerFilePatterns: ["/gemini-extension\\.json$/"],
+      managerFilePatterns: [
+        "/mcp\\.json$/",
+        "/mcp_config\\.json$/",
+        "/gemini-extension\\.json$/",
+        "/\\.claude-plugin/plugin\\.json$/",
+        "/\\.codex-plugin/\\.mcp\\.json$/",
+      ],
       matchStrings: ["@toolbox-sdk/server@(?<currentValue>[\\d\\.]+)"],
       datasourceTemplate: "npm",
       depNameTemplate: "@toolbox-sdk/server",

--- a/mcp.json
+++ b/mcp.json
@@ -6,7 +6,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "postgres",
         "--stdio"

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "postgres",
         "--stdio"

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "postgres",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Connect and interact with a PostgreSQL database and data",
   "author": {
     "name": "Google LLC",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,7 +30,22 @@
       "extra-files": [
         {
           "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "gemini-extension.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
           "jsonpath": "$.version"
         }
       ]


### PR DESCRIPTION
Both automations were bumping only `gemini-extension.json`, so the source (`plugin.json` + `mcp.json`) and the other generated manifests drifted.